### PR TITLE
Support `pyzmq` 27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">= 3.9"
 dependencies = [
     "anyio >=4.8.0,<5.0.0",
     "anyioutils >=0.7.1,<0.8.0",
-    "pyzmq >=26.0.0,<27.0.0",
+    "pyzmq >=26.0.0,<28.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
According to the [release notes for PyZMQ 27.0](https://pyzmq.readthedocs.io/en/latest/changelog.html#id2), there are no breaking changes.

I also gave the PRs/[commits between v26.4.0 and v27.0.0](https://github.com/zeromq/pyzmq/compare/v26.4.0...v27.0.0) a brief look and didn't see anything major.